### PR TITLE
ファイルサイズチェック処理の変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.3-buster-slim
+FROM --platform=linux/amd64 node:16.19.1-buster-slim
 
 LABEL maintainer="Piotr Antczak <antczak.piotr@gmail.com>"
 WORKDIR /clamav-rest-api

--- a/Dockerfile_UnitTest
+++ b/Dockerfile_UnitTest
@@ -1,0 +1,17 @@
+FROM --platform=linux/amd64 node:16.19.1-buster-slim
+
+LABEL maintainer="Piotr Antczak <antczak.piotr@gmail.com>"
+WORKDIR /clamav-rest-api
+
+COPY src ./src/
+COPY package.json package-lock.json ./
+
+RUN  apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y apt-utils wait-for-it && \
+    npm install && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    chown -R node:node ./
+
+USER node:node
+CMD ["npm", "start"]

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,18 +1,19 @@
 version: '3.8'
 services:
   clamd:
-    image: clamav/clamav:0.104
+    image: clamav/clamav:1.0.1
     restart: unless-stopped
     networks:
       - clam-net
   api:
-    image: benzino77/clamav-rest-api
+    build: ../
+    image: clamav-rest-api
     restart: unless-stopped
     # depends_on is ignored in some situations (have a look at the discussion in this PR: https://github.com/benzino77/clamav-rest-api/pull/23)
     # to fix such situation there is wait-for-it script available inside the CRA docker image (https://github.com/vishnubob/wait-for-it)
     # so to wait for clamd to be available, one could ovewrite the CMD with wait-for-it script
     # UNCOMMENT following line to check if clamav is available on host clamd and port 3310, set timeout to 60 seconds
-    # command: ['/usr/bin/wait-for-it', '-h', 'clamd', '-p', '3310', '-s', '-t', '60', '--', 'npm', 'start']
+    command: ['/usr/bin/wait-for-it', '-h', 'clamd', '-p', '3310', '-s', '-t', '60', '--', 'npm', 'start']
     depends_on:
       - clamd
     environment:
@@ -20,6 +21,7 @@ services:
       - CLAMD_IP=clamd
       - APP_FORM_KEY=FILES
       - APP_PORT=3000
+      - APP_MAX_FILE_SIZE=6291456 # 6MiB
     ports:
       - '8080:3000'
     networks:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - clam-net
   api:
     build: ../
-    image: clamav-rest-api
     restart: unless-stopped
     # depends_on is ignored in some situations (have a look at the discussion in this PR: https://github.com/benzino77/clamav-rest-api/pull/23)
     # to fix such situation there is wait-for-it script available inside the CRA docker image (https://github.com/vishnubob/wait-for-it)
@@ -21,7 +20,7 @@ services:
       - CLAMD_IP=clamd
       - APP_FORM_KEY=FILES
       - APP_PORT=3000
-      - APP_MAX_FILE_SIZE=6291456 # 6MiB
+      - APP_MAX_FILE_SIZE=10485760 # 10MiB
     ports:
       - '8080:3000'
     networks:

--- a/examples/test/docker-compose.yml
+++ b/examples/test/docker-compose.yml
@@ -1,13 +1,10 @@
 version: '3.8'
 services:
   api:
-    build: ../../
-    image: clamav-rest-api
+    build:
+      context: ../../
+      dockerfile: Dockerfile_UnitTest
     restart: 'no'
-    # depends_on is ignored in some situations (have a look at the discussion in this PR: https://github.com/benzino77/clamav-rest-api/pull/23)
-    # to fix such situation there is wait-for-it script available inside the CRA docker image (https://github.com/vishnubob/wait-for-it)
-    # so to wait for clamd to be available, one could ovewrite the CMD with wait-for-it script
-    # UNCOMMENT following line to check if clamav is available on host clamd and port 3310, set timeout to 60 seconds
     command: ['npm', 'test']
     environment:
       - NODE_ENV=test

--- a/examples/test/docker-compose.yml
+++ b/examples/test/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  api:
+    build: ../../
+    image: clamav-rest-api
+    restart: 'no'
+    # depends_on is ignored in some situations (have a look at the discussion in this PR: https://github.com/benzino77/clamav-rest-api/pull/23)
+    # to fix such situation there is wait-for-it script available inside the CRA docker image (https://github.com/vishnubob/wait-for-it)
+    # so to wait for clamd to be available, one could ovewrite the CMD with wait-for-it script
+    # UNCOMMENT following line to check if clamav is available on host clamd and port 3310, set timeout to 60 seconds
+    command: ['npm', 'test']
+    environment:
+      - NODE_ENV=test
+      - CLAMD_IP=clamd
+      - APP_FORM_KEY=FILES
+      - APP_PORT=3000
+      - APP_MAX_FILE_SIZE=2097152
+      - APP_MAX_FILES_NUMBER=2
+    ports:
+      - '8080:3000'

--- a/src/config.js
+++ b/src/config.js
@@ -12,23 +12,6 @@ const avConfig = {
 
 const fuConfig = {
   useTempFiles: false,
-  limits: {
-    fileSize: parseInt(process.env.APP_MAX_FILE_SIZE),
-  },
-  limitHandler: (req, res) => {
-    res.writeHead(413, {
-      Connection: 'close',
-      'Content-Type': 'application/json',
-    });
-    res.end(
-      JSON.stringify({
-        success: false,
-        data: {
-          error: `File size limit exceeded. Max size of uploaded file is: ${process.env.APP_MAX_FILE_SIZE / 1024} KB`,
-        },
-      })
-    );
-  },
 };
 
 module.exports = {

--- a/src/routes/scan.js
+++ b/src/routes/scan.js
@@ -21,6 +21,18 @@ router.route('/').post(async (req, res, next) => {
     ? req.files[process.env.APP_FORM_KEY]
     : [req.files[process.env.APP_FORM_KEY]];
 
+  // file size check
+  for (const f of toScan) {
+    if (f.size > process.env.APP_MAX_FILE_SIZE) {
+      return res.status(413).json({
+        success: false,
+        data: {
+          error: `File size limit exceeded. Max size of uploaded file is: ${process.env.APP_MAX_FILE_SIZE / 1024} KB`,
+        },
+      });
+    }
+  }
+
   let resultArray = [];
   for (const f of toScan) {
     try {


### PR DESCRIPTION
## 課題

https://github.com/quocard/clamav-rest-api/pull/1 の結果、`APP_MAX_FILE_SIZE`で指定した値より大きなファイルをスキャンした時に、下記エラーが発生するようになった。

> Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client

## 対応

